### PR TITLE
Fix incorrect error when dealing with rails blocks in some cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .github_changelog_generator
+*~

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,17 +74,10 @@ export default {
 
         // Call ERB to "de-templatize" the code
         return helpers.exec(this.erbPath, erbArgs,
-          { stdin: text, cwd: fileDir }
+          { stdin: text.replace(/<%=/g, '<%'), cwd: fileDir }
         ).then(erbOut => {
-          let rubyCode = erbOut;
-          // Deal with the <%= function_with trailing block do %> ... <% end %>
-          // From Ruby on Rails code
-          const scopes = textEditor.getLastCursor().getScopeDescriptor().getScopesArray();
-          if (scopes.indexOf('text.html.erb') !== -1) {
-            rubyCode = erbOut.replace(/_erbout.concat\(\((.+?do.+?)\).to_s\)/g, '\$1');
-          }
           // Run Ruby on the "de-templatized" code
-          const rubyProcessOpt = { stdin: rubyCode, stream: 'stderr' };
+          const rubyProcessOpt = { stdin: erbOut, stream: 'stderr' };
           return helpers.exec(this.rubyPath, rubyArgs, rubyProcessOpt).then(output => {
             const regex = /.+:(\d+):\s+(?:.+?)[,:]\s(.+)/g;
             const messages = [];

--- a/spec/fixtures/rails_blocks.erb
+++ b/spec/fixtures/rails_blocks.erb
@@ -1,0 +1,19 @@
+<%= form_for something do %>
+  <%= link_to thing %>
+<% end %>
+
+<%= form_for(
+  something
+) do %>
+  <%= link_to thing %>
+<% end %>
+
+<%= form_for something do |f| %>
+  <%= link_to thing %>
+<% end %>
+
+<%= form_for(
+  something
+) do |f| %>
+  <%= link_to thing %>
+<% end %>

--- a/spec/linter-erb-spec.js
+++ b/spec/linter-erb-spec.js
@@ -53,6 +53,17 @@ describe('The ERB provider for Linter', () => {
     });
   });
 
+  it('finds nothing wrong with a file with rails type blocks', () => {
+    waitsForPromise(() => {
+      const blocksFile = path.join(__dirname, 'fixtures', 'rails_blocks.erb');
+      return atom.workspace.open(blocksFile).then(editor =>
+        lint(editor).then(messages => {
+          expect(messages.length).toEqual(0);
+        })
+      );
+    });
+  });
+
   it('finds nothing wrong with a valid file', () => {
     waitsForPromise(() => {
       const goodFile = path.join(__dirname, 'fixtures', 'good.erb');


### PR DESCRIPTION
If a rails helper function that accepts blocks was written in a way to have newlines in between arguments, that expression would be marked as an error when it is in fact valid syntax. Example:

    <%= form_for(
      something
    ) do %>
    <% end %>

This syntax is in fact incorrect ERB, so the linter is correct in marking it as an error, but Rails allows it and produces the expected result.

The problem in `linter-erb` was caused by the regex used to capture that case not being written in a way to handle newlines. Instead of trying to edit the regex to handle all possible use cases a much more simple solution was used. All `<%=` occurrences will simply be replaced by `<%` before being passed to the external linter, and that prevents any errors from being detected. This is the same solution used by other projects, e.g. [syntastic](https://github.com/scrooloose/syntastic/commit/0f1d451d96970de4b1f07290f6231f9411749919).

Fixes #36.