### PR TITLE
Move to eslint-config-airbnb-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,25 +21,26 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
+  "scripts": {
+    "lint": "eslint .",
+    "test": "apm test"
+  },
   "dependencies": {
     "atom-linter": "^4.5.1",
     "atom-package-deps": "^4.0.1"
   },
   "devDependencies": {
-    "eslint": "^2.7.0",
-    "eslint-config-airbnb": "^7.0.0",
-    "eslint-plugin-react": "^4.3.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2"
+    "eslint": "^2.9.0",
+    "eslint-config-airbnb-base": "^2.0.0",
+    "eslint-plugin-import": "^1.6.1"
   },
   "eslintConfig": {
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-console": 0
+      "comma-dangle": [2, "never"],
+      "global-require": 0,
+      "import/no-unresolved": [2, {"ignore": ["atom"]}]
     },
-    "extends": "airbnb/base",
+    "extends": "airbnb-base",
     "globals": {
       "atom": true
     },

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
-  globals: {
-    waitsForPromise: true
-  },
   env: {
+    atomtest: true,
     jasmine: true
   }
 };

--- a/spec/linter-erb-spec.js
+++ b/spec/linter-erb-spec.js
@@ -2,9 +2,9 @@
 
 import * as path from 'path';
 
-describe('The ERB provider for Linter', () => {
-  const lint = require(path.join('..', 'lib', 'index.js')).provideLinter().lint;
+const lint = require(path.join('..', 'lib', 'index.js')).provideLinter().lint;
 
+describe('The ERB provider for Linter', () => {
   beforeEach(() => {
     atom.workspace.destroyActivePaneItem();
     waitsForPromise(() => {


### PR DESCRIPTION
There is no need for the React components of `eslint-config-airbnb`.

Closes #43.
Closes #47.
Closes #49.