### PR TITLE
Update CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,25 @@
+### Project specific config ###
+language: ruby
+
+matrix:
+  include:
+    - os: linux
+      rvm: 2.3.1
+
+    - os: linux
+      rvm: 2.3.1
+      env: ATOM_CHANNEL=beta
+
+    - os: osx
+      rvm: 2.2.3
+
+before_script:
+  - ruby --version
+  - erb --version
+
+### Generic setup follows ###
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+
 notifications:
   email:
     on_success: never
@@ -7,31 +29,10 @@ branches:
   only:
     - master
 
-language: ruby
-rvm:
-  - 2.2.3
-before_script:
-  - ruby --version
-  - erb --version
-
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
-
 git:
   depth: 10
 
 sudo: false
-
-os:
-  - linux
-  - osx
-
-env:
-  global:
-    - APM_TEST_PACKAGES=""
-
-  matrix:
-    - ATOM_CHANNEL=stable
-    - ATOM_CHANNEL=beta
 
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,25 +1,23 @@
-version: "{build}"
-os: Windows Server 2012 R2
-branches:
-  only:
-    - master
-test: off
-deploy: off
-
+### Project specific config ###
 environment:
   ruby_version: "22-x64"
 
-install:
-  - appveyor DownloadFile https://atom.io/download/windows -FileName AtomSetup.exe
-  - AtomSetup.exe /silent
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - SET PATH=%LOCALAPPDATA%\atom\bin;%PATH%
+before_build:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-
-build_script:
   - ruby --version
   - erb --version
-  - apm -v
-  - apm clean
-  - apm install
-  - apm test
+
+### Generic setup follows ###
+build_script:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
+
+branches:
+  only:
+    - master
+
+version: "{build}"
+platform: x64
+clone_depth: 10
+skip_tags: true
+test: off
+deploy: off

--- a/circle.yml
+++ b/circle.yml
@@ -1,20 +1,12 @@
+test:
+  override:
+    - curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh
+
+dependencies:
+  override:
+    # If nothing is put here, CircleCI will run `npm install` using the system Node.js
+    - echo "Managed in the script"
+
 machine:
   ruby:
     version: 2.2.3
-dependencies:
-  pre:
-    # Force updating wget due to the current containers being too out of date
-    - sudo apt-get update
-    - sudo apt-get install wget
-  override:
-    - wget -O atom-amd64.deb https://atom.io/download/deb
-    # - sudo apt-get update # Cut out until wget is fixed on the containers
-    - sudo dpkg --install atom-amd64.deb || true
-    - sudo apt-get -f install
-    - apm install
-test:
-  override:
-    - atom -v
-    - apm -v
-    - ./node_modules/.bin/eslint ./
-    - apm test


### PR DESCRIPTION
* Move CircleCI to the atom/ci script that Travis-CI uses
* Cut out the beta build on OS X
* Move AppVeyor to the script on atom/ci
* Updates the tested Ruby to 2.3.1 on Linux.