### PR TITLE
Pass fileDir as ‘cwd’ to ruby process.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,7 @@ export default {
           { stdin: text.replace(/<%=/g, '<%'), cwd: fileDir },
         ).then((erbOut) => {
           // Run Ruby on the "de-templatized" code
-          const rubyProcessOpt = { stdin: erbOut, stream: 'stderr', allowEmptyStderr: true };
+          const rubyProcessOpt = { stdin: erbOut, stream: 'stderr', allowEmptyStderr: true, cwd: fileDir };
           return helpers.exec(this.rubyPath, rubyArgs, rubyProcessOpt).then((output) => {
             const regex = /.+:(\d+):\s+(?:.+?)[,:]\s(.+)/g;
             const messages = [];


### PR DESCRIPTION
This makes sure the ruby version used to lint the _erb_ template is the one specified on the project the user is working on.