### PR TITLE
Change the default trim type to -

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ are available:
     `ruby`.
 
 *   `trimMode`: Select the trim mode used by ERB when generating the code
-    before sending off to Ruby for checking. Defaults to no trimming. For a
-    full description of what the options mean see [the documentation][erb-docs].
+    before sending off to Ruby for checking. Defaults to `-` for out-of-the-box
+    compatibility with Rails. For a full description of what the options mean
+    see [the documentation][erb-docs].
 
     _**Note**_: Modes other than `None` _may_ cause the error line numbers to
     not match the source line numbers.

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ export default {
       description: 'What trim mode ERB should use',
       type: 'string',
       enum: ['None', '0', '1', '2', '-'],
-      default: 'None',
+      default: '-',
     },
     rubyExecutablePath: {
       description: 'Path to the `ruby` executable',

--- a/spec/fixtures/rails_blocks.erb
+++ b/spec/fixtures/rails_blocks.erb
@@ -17,3 +17,7 @@
 ) do |f| %>
   <%= link_to thing %>
 <% end %>
+
+<% no_line_break -%>
+
+<%- no_line_breaks -%>


### PR DESCRIPTION
This is required for Rails compatible ERB files and it has caused at least one report from a user in the past that had to set it manually to get these files properly linted. It doesn't appear to cause any harm and should provide a more pleasant experience for Rails users.

Fixes #54.