### PR TITLE
chore: pin eslint to 4.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "atom-package-deps": "^4.0.1"
   },
   "devDependencies": {
-    "eslint": "^4.6.0",
+    "eslint": "4.12.0",
     "eslint-config-airbnb-base": "^12.0.0",
     "eslint-plugin-import": "^2.7.0",
     "jasmine-fix": "^1.3.0"


### PR DESCRIPTION
Pinning this to a version that works for now. Anyone that wants to check why newer versions are failing is free to submit a PR.