### PR TITLE
Initial Adoption of Continous Deployment using semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,15 @@ addons:
     - git
     - libgnome-keyring-dev
     - fakeroot
+
+node_js: lts/*
+
+after_success:
+  # Add apm to the PATH
+  - export PATH=${PATH}:${HOME}/atom/usr/bin/
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - npx semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,49 @@
 ### Project specific config ###
 language: ruby
 dist: trusty
+env: ATOM_CHANNEL=stable
+os: linux
+rvm: 2.4
+script: skip
 
-matrix:
+jobs:
   include:
-    - os: linux
-      rvm: 2.3.1
+    - stage: test
+      env: ATOM_CHANNEL=stable
 
-    - os: linux
-      rvm: 2.3.1
+    - stage: test
       env: ATOM_CHANNEL=beta
+
+    - stage: test
+      language: node_js
+      node_js: lts/*
+      install:
+        - npm install
+      script:
+        - commitlint-travis
+
+    - stage: release
+      before_deploy:
+        - export PATH=${PATH}:${HOME}/atom/usr/bin/
+        - nvm install lts/*
+        - node --version
+        - npm --version
+        - npx --version
+      deploy:
+        provider: script
+        skip_cleanup: true
+        script:
+          - npx semantic-release
 
 before_script:
   - ruby --version
   - erb --version
 
 ### Generic setup follows ###
-script:
+install:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
   - chmod u+x build-package.sh
-  - ./build-package.sh
+  - "./build-package.sh"
 
 notifications:
   email:
@@ -44,14 +68,7 @@ addons:
     - libgnome-keyring-dev
     - fakeroot
 
-node_js: lts/*
-
-after_success:
-  # Add apm to the PATH
-  - export PATH=${PATH}:${HOME}/atom/usr/bin/
-
-deploy:
-  provider: script
-  skip_cleanup: true
-  script:
-    - npx semantic-release
+stages:
+  - test
+  - name: release
+    if: (NOT type = pull_request) AND branch = master

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "Linter plugin for ERB, using erb -x",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AtomLinter/linter-erb"
+    "url": "https://github.com/AtomLinter/linter-erb.git"
   },
   "keywords": [
     "linter",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "atom": ">=1.7.0 <2.0.0"
   },
   "scripts": {
+    "commitmsg": "commitlint -e $GIT_PARAMS",
     "lint": "eslint .",
     "test": "apm test"
   },
@@ -54,6 +55,12 @@
     "atom-package-deps": "^4.0.1"
   },
   "devDependencies": {
+    "@commitlint/cli": "^6.1.3",
+    "@commitlint/config-conventional": "^6.1.3",
+    "@commitlint/travis-cli": "^6.1.3",
+    "@semantic-release/apm-config": "^2.0.1",
+    "husky": "^0.14.3",
+    "semantic-release": "^15.1.7",
     "eslint": "^4.6.0",
     "eslint-config-airbnb-base": "^12.0.0",
     "eslint-plugin-import": "^2.7.0",
@@ -94,5 +101,13 @@
   "activationHooks": [
     "language-ruby:grammar-used",
     "language-ruby-on-rails:grammar-used"
-  ]
+  ],
+  "release": {
+    "extends": "@semantic-release/apm-config"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
+  }
 }


### PR DESCRIPTION
To ease the modification/contribution to publish pipeline there has been some discussion of adopting a continuous deployment system for AtomLinter packages. To accomplish this we are making use of [`semantic-release`](https://github.com/semantic-release/semantic-release) and [`@semantic-release/apm-config`](https://github.com/semantic-release/apm-config).

This pull request has been [dynamically created using a script](https://gist.github.com/keplersj/8bc7622ea741c0964d12842bfc679c5d). While the result is not perfect, it does accompish most of the grunt work of adopting continous deployment. There is some reconciliation that needs to be done before this can be merged.

Among the things needed to be reconciled, an [APM Token](https://atom.io/account) and [GitHub Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) will need to be added to this repo's continous integration (most likely [Travis CI](https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings)) configuration for automated deployments to work.

Again, this Pull Request has been created by a script made by @keplersj. Please mention him if something has gone wrong, and he'll be happy to help.

ref: AtomLinter/Meta#18

cc: @Arcanemagus
