### PR TITLE
Pin Node version to 8 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
   checkout_code:
     <<: *defaults
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:8
     steps:
       - checkout
       # Restore node_modules from the last build
@@ -62,7 +62,7 @@ jobs:
   lint:
     <<: *defaults
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:8
     steps:
       # Restore project state
       - attach_workspace:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,9 @@ If you would like to contribute enhancements or fixes, please do the following:
 Please note that modifications should follow these coding guidelines:
 
 -   Indent is 2 spaces.
--   Code should pass `eslint` linter.
--   Vertical whitespace helps readability, don’t be afraid to use it.
+-   Code should pass `eslint` linter (`npm run lint`).
+-   Commit messages must follow the [Angular Git Commit Guidelines][angular-commit].
 
 Thank you for helping out!
+
+[angular-commit]: https://github.com/marionebl/commitlint/tree/master/@commitlint/config-conventional


### PR DESCRIPTION
Since Node 10 started to be used on CircleCI we've been experiencing some intermittent build hangs where the process would timeout on the `npm install` step without any error messages.

This is an attempt at working around that issue.

Closes #128.