### PR TITLE
Fix husky configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "atom": ">=1.7.0 <2.0.0"
   },
   "scripts": {
-    "commitmsg": "commitlint -e $GIT_PARAMS",
     "lint": "eslint .",
     "test": "apm test"
   },
@@ -109,5 +108,10 @@
     "extends": [
       "@commitlint/config-conventional"
     ]
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
   }
 }


### PR DESCRIPTION
`husky@1` changed how git hook configuration is supposed to be specified.

 This was missed in merging #131, and fixed here.